### PR TITLE
fix: use relative paths to find the generated view file in exclude root

### DIFF
--- a/src/main/kotlin/dev/fastball/intellij/plugin/constants.kt
+++ b/src/main/kotlin/dev/fastball/intellij/plugin/constants.kt
@@ -17,7 +17,7 @@ const val FASTBALL_SETTING_DEFAULT_PROXY_TARGET = "http://localhost:8080"
 const val JAVA_FILE_EXT = "java"
 const val VIEW_FILE_EXT = "fbv.json"
 const val FASTBALL_VIEW_DIR_NAME = "FASTBALL-INF"
-const val FASTBALL_GENERATE_VIEW_DIR = "/target/classes/$FASTBALL_VIEW_DIR_NAME"
+const val FASTBALL_GENERATE_VIEW_DIR = "/classes/$FASTBALL_VIEW_DIR_NAME"
 const val FASTBALL_MATERIAL_FILE_NAME = "fastball-material.yml"
 
 const val EDITOR_TAB_NAME = "UI Editor"

--- a/src/main/kotlin/dev/fastball/intellij/plugin/utils.kt
+++ b/src/main/kotlin/dev/fastball/intellij/plugin/utils.kt
@@ -6,11 +6,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode
 import com.intellij.openapi.module.ModuleUtil
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.roots.ModuleRootManager
-import com.intellij.openapi.vfs.LocalFileSystem
 import com.intellij.openapi.vfs.VirtualFile
-import com.intellij.openapi.vfs.VirtualFileManager
-import com.intellij.openapi.vfs.VirtualFileSystem
-import com.intellij.psi.PsiFileFactory
 import org.jetbrains.jps.model.java.JavaResourceRootType
 import org.jetbrains.jps.model.java.JavaSourceRootType
 import java.io.InputStream
@@ -86,7 +82,7 @@ fun getCustomizedViewFile(module: com.intellij.openapi.module.Module, javaRelati
     }
 
 fun getGeneratedViewFile(module: com.intellij.openapi.module.Module, javaRelativePath: String) =
-    ModuleRootManager.getInstance(module).contentRoots.firstNotNullOfOrNull {
+    ModuleRootManager.getInstance(module).excludeRoots.firstNotNullOfOrNull {
         it.findFileByRelativePath("$FASTBALL_GENERATE_VIEW_DIR$javaRelativePath.$VIEW_FILE_EXT")
     }
 


### PR DESCRIPTION
target 为一般情况的 maven 编译路径，<build><directory>${basedir}/other</directory></build> 可以修改。还是用 excludeRoots 比较合适。